### PR TITLE
Fix: 제품 상세 페이지에서 보여줄 리뷰 갯수를 프론트에서 받는 로직으로 변경

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -14,7 +14,9 @@ const getProductList = async (req, res) => {
 const getProductDetail = async (req, res) => {
   try {
     const { product_id } = req.params;
-    const productDetail = await productService.getProductDetail(product_id)    
+    const { limit } = req.query;
+
+    const productDetail = await productService.getProductDetail(product_id, limit)    
   
     return res.status(200).json(productDetail)
   } catch (error) {

--- a/models/productDao.js
+++ b/models/productDao.js
@@ -18,7 +18,7 @@ const getProductList = async () => {
   })
 }
 
-const getProductDetail = async (product_id) => {
+const getProductDetail = async (product_id, limit) => {
   return await prisma.products.findUnique({
     select: {
       name: true,
@@ -31,6 +31,7 @@ const getProductDetail = async (product_id) => {
         }
       },
       reviews: {
+        take: limit,
         select: {
           id: true,
           rating: true,

--- a/models/productDao.js
+++ b/models/productDao.js
@@ -2,20 +2,23 @@ const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
 const getProductList = async () => {
-  return await prisma.products.findMany({
-    select: {
-      id: true,
-      name: true,
-      image_url: true,
-      price_before: true,
-      price_after: true,
-      brands: {
-        select: {
-          name: true
-        }
-      }
-    }
-  })
+  return await prisma.$queryRaw`
+    SELECT 
+      p.id, p.name, p.image_url, p.price_before, p.price_after, 
+      b.name AS "brand_name", r.ratingAvg, r.contentCnt
+    FROM 
+      products p
+    LEFT JOIN 
+      brands b
+    ON b.id = p.brand_id
+    LEFT JOIN 
+      (SELECT r.product_id, AVG(r.rating) AS ratingAvg, COUNT(r.content) AS contentCnt
+        FROM reviews r
+        GROUP BY r.product_id
+      ) r
+    ON r.product_id = p.id
+    ;
+  `
 }
 
 const getProductDetail = async (product_id, limit) => {
@@ -59,8 +62,23 @@ const getProductDetail = async (product_id, limit) => {
   })
 }
 
+const getProductReviewSum = async (product_id) => {
+  return await prisma.reviews.aggregate({
+    _avg: {
+      rating: true
+    },
+    _count: {
+      content: true
+    },
+    where: {
+      product_id: product_id
+    }
+  })
+}
+
 
 module.exports = {
   getProductList,
-  getProductDetail
+  getProductDetail,
+  getProductReviewSum
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,7 +8,6 @@ const cartRoute = require("./cartRoute");
 const reviewRoute = require("./reviewRoute");
 
 
-// router.use('/', productRoute)
 router.use('/user', userRoute)
 router.use('/product', productRoute)
 router.use('/cart', cartRoute)

--- a/routes/productRoute.js
+++ b/routes/productRoute.js
@@ -3,8 +3,8 @@ const router = express.Router();
 
 const productController = require("../controllers/productController");
 
-router.get("/", productController.getProductList);
-router.get("/:product_id", productController.getProductDetail);
+router.get("/list", productController.getProductList);
+router.get("/detail/:product_id", productController.getProductDetail);
 
 
 module.exports = router

--- a/services/productService.js
+++ b/services/productService.js
@@ -4,9 +4,12 @@ const getProductList = async () => {
   return await productDao.getProductList()
 }
 const getProductDetail = async (product_id, limit) => {
-  return await productDao.getProductDetail(Number(product_id), Number(limit))
-}
+  const detail =  await productDao.getProductDetail(Number(product_id), Number(limit))
+  const reviewSum = await productDao.getProductReviewSum(Number(product_id))
 
+  detail.reviewSum = reviewSum
+  return detail
+}
 
 module.exports = {
   getProductList,

--- a/services/productService.js
+++ b/services/productService.js
@@ -3,8 +3,8 @@ const productDao = require("../models/productDao");
 const getProductList = async () => {
   return await productDao.getProductList()
 }
-const getProductDetail = async (product_id) => {
-  return await productDao.getProductDetail(product_id)
+const getProductDetail = async (product_id, limit) => {
+  return await productDao.getProductDetail(Number(product_id), Number(limit))
 }
 
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 제품 상세 페이지에서 보여줄 리뷰 갯수를 제한하는 기능을 추가하고 리뷰 평점, 리뷰 수를 추가 했습니다.
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 제품 상세 페이지에서 리뷰 갯수 제한하는 기능 추가
- 보여줄 리뷰 갯수를 쿼리 파라미터로 가져와서 그 갯수만큼만 반환합니다.

2. 제품 조회시 리뷰 평점, 리뷰 수를 추가해서 반환
- 메인에서 전체 제품 조회시, 제품 상세 페이지에서 조회시 리뷰 평점과 리뷰 수 정보도 같이 반환합니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 리뷰 갯수와 제품 아이디를 둘 다 쿼리 파라미터로 가져오려고 했으나 다른 라우터와 겹치는 문제 때문에 리뷰 갯수는 쿼리 파라미터로 가져오고 제품 아이디는 기본 파라미터에서 가져오는 로직으로 만들었습니다. 라우터를 만들 때 신중하게 만드는 게 중요하다고 생각했습니다!
- 리뷰 평점과 리뷰 수를 prisma 내장함수로 작성하다가 어려움이 많아서.. queryRaw로 작성했습니다. SQL  query문으로 작성하면 더 섬세하게 작업할 수가 있는 장점이 있다고 생각합니다!
<br />
